### PR TITLE
박정태 네이버 블로그를 티스토리로 이관합니다.

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -4046,9 +4046,9 @@
   rss: https://medium.com/feed/@aiden.p
   description: 블록체인, 이더리움
 - name: 박정태
-  blog: https://blog.naver.com/pjt3591oo
-  rss: https://rss.blog.naver.com/pjt3591oo.xml
-  description: Back-end, 서버
+  blog: https://meongae.tistory.com/
+  rss: https://meongae.tistory.com/rss
+  description: 벡엔드, 블록체인, 인공지능
   github: https://github.com/pjt3591oo
   facebook: https://www.facebook.com/profile.php?id=100003874674961
   stackoverflow: https://stackoverflow.com/story/mung


### PR DESCRIPTION
기존에 운영하던 기술 + 일상 블로그인 네이버 블로그를 기술 블로그 목적인 티스토리로 이관작업을 위해 블로그 변경합니다