### PR TITLE
블로그 설명 및 링크 수정

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -380,9 +380,9 @@
   linkedin: https://www.linkedin.com/in/jin-gi-kong-289154121/
 - name: 공채원
   blog: https://leonkong.cc/
-  description: React Native
-  github: https://github.com/ChaeWonKong
-  facebook: https://www.facebook.com/wonchaekong
+  description: back-end
+  github: https://github.com/chaewonkong
+  linkedin: https://www.linkedin.com/in/chaewonkong/
 - name: 곽민수
   blog: https://brunch.co.kr/@imagineer
   rss: https://brunch.co.kr/rss/@@YZF


### PR DESCRIPTION
1. 블로그 설명을 수정합니다 (React Native -> back-end)
2. 링크드인 링크를 추가하는 대신 facebook 링크를 삭제합니다 (facebook 링크 유효하지 않음)
3. github 계정명이 소문자로 변경되어 이 부분 반영해 수정합니다.