### PR TITLE
Fix teamhide url

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -11027,8 +11027,8 @@
   linkedin: https://www.linkedin.com/in/younho-choo-87b5151a0/
   twitter: https://twitter.com/younho_9
 - name: 추영식
-  blog: https://hides.kr
-  rss: https://hides.kr/rss
+  blog: https://hides.tistory.com
+  rss: https://hides.tistory.com/rss
   facebook: https://www.facebook.com/sharehead
 - name: 편해걸
   blog: https://hg-pyun.github.io/


### PR DESCRIPTION
개인 도메인으로 연결하니, RSS에서 www가 앞에 붙어서 연결이 안되네요. 그냥 티스토리 주소로 변경요청합니다.