### PR TITLE
접속 불가능한 블로그 제거 및 일부 블로그 RSS 변경

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -4201,7 +4201,7 @@
   linkedin: https://www.linkedin.com/in/94junpyop/
 - name: 박준호
   blog: https://www.junojunho.com/
-  rss: https://www.junojunho.com/feed
+  rss: https://junojunho.com/index.xml
   github: https://github.com/cnaa97
   linkedin: https://www.linkedin.com/in/cnaa97/
   description: Front-end

--- a/db.yml
+++ b/db.yml
@@ -5762,8 +5762,8 @@
   github: https://github.com/eungyeole
   home: https://eungyeole.super.site/
 - name: 안이수
-  blog: https://www.ooseel.net/me/
-  rss: https://www.ooseel.net/me/index.xml
+  blog: https://www.ooseel.net/
+  rss: https://www.ooseel.net/index.xml
   description: webOS, GNOME
   github: https://github.com/memnoth
   gitlab: https://gitlab.gnome.org/memnoth

--- a/db.yml
+++ b/db.yml
@@ -2564,7 +2564,7 @@
   github: https://github.com/greekZorba
 - name: 김진혁
   blog: https://tk-one.github.io/
-  rss: https://tk-one.github.io/atom.xml
+  rss: https://tk-one.github.io/rss2.xml
   description: Node.js
   facebook: https://www.facebook.com/MiraGeKJH
   github: https://github.com/TK-one

--- a/db.yml
+++ b/db.yml
@@ -8860,11 +8860,6 @@
   blog: https://mooneegee.blogspot.kr/
   rss: https://mooneegee.blogspot.com/feeds/posts/default
   description: 3D
-- name: 장범준
-  blog: https://tjtdkr.me/
-  rss: https://tjtdkr.me/feed.xml
-  github: https://github.com/tjtdkr
-  facebook: https://www.facebook.com/tjtdkr
 - name: 장봄
   blog: https://velog.io/@denmark-choco
   rss: https://v2.velog.io/rss/denmark-choco

--- a/db.yml
+++ b/db.yml
@@ -10175,12 +10175,6 @@
   github: https://github.com/zerocho
   youtube: https://www.youtube.com/channel/UCp-vBtwvBmDiGqjvLjChaJw
   npm: https://www.npmjs.com/~zerocho
-- name: 조현제
-  blog: http://hyunje.com/
-  rss: http://hyunje.com/feed.xml
-  description: Data Analysis
-  facebook: https://www.facebook.com/Retriever.Jo
-  github: https://github.com/retrieverJo
 - name: 조현종
   blog: https://hangumkj.blogspot.com/
   rss: https://hangumkj.blogspot.com/feeds/posts/default

--- a/db.yml
+++ b/db.yml
@@ -8763,12 +8763,6 @@
   description: Java
   twitter: https://twitter.com/jinwooe
   rocketpunch: https://www.rocketpunch.com/@jinwooe.1
-- name: 임창현
-  blog: https://www.three-snakes.com/
-  rss: https://www.three-snakes.com/rss.xml
-  github: https://github.com/threesnakes
-  linkedin: https://www.linkedin.com/in/changhyun-lim-86334a194/
-  description: Web, Front
 - name: 임채성
   blog: https://puleugo.tistory.com/
   rss: https://puleugo.tistory.com/rss

--- a/db.yml
+++ b/db.yml
@@ -4417,10 +4417,6 @@
   linkedin: https://www.linkedin.com/in/1ambda/
   github: https://github.com/1ambda
   facebook: https://www.facebook.com/1ambda
-- name: 박희근
-  blog: https://sirini.blog/
-  rss: https://sirini.blog/feed/
-  description: GR BOARD
 - name: 박희우
   github: https://github.com/parkhuiwo0
   facebook: https://www.facebook.com/parkhuiwo0

--- a/db.yml
+++ b/db.yml
@@ -9194,8 +9194,6 @@
   description: Spring
   github: https://github.com/supawer0728
 - name: 전창완
-  blog: https://wani.kr/
-  rss: https://wani.kr/feed.xml
   description: PHP, Backend
   github: https://github.com/wan2land
   twitter: https://twitter.com/wan2land

--- a/db.yml
+++ b/db.yml
@@ -6099,10 +6099,6 @@
   blog: https://wergia.tistory.com/
   rss: https://wergia.tistory.com/rss
   description: 게임 개발
-- name: 오상준
-  blog: https://www.namooz.com/
-  rss: https://www.namooz.com/feed/
-  description: Spring Boot, Angular2
 - name: 오세용
   blog: http://ohseyong.com/
   rss: http://ohseyong.com/?feed=rss2


### PR DESCRIPTION
http://hyunje.com 접속 불가 ERR_EMPTY_RESPONSE ECONNRESET 에러

sirini.blog 접속 불가 ENOTFOUND

tjtdkr.me 접속시 광고 페이지 표출 - 도메인 만료로 보임

tk-one.github.io RSS 주소 변경됨

wani.kr 접속 불가 ECONNREFUSED 에러

www.junojunho.com RSS 주소 변경됨

www.namooz.com 접속시 광고 페이지 표출 - 도메인 만료로 보임

www.three-snakes.com 접속시 광고 페이지 표출 - 도메인 만료로 보임

안녕하세요! awesome-devblog 에서 제공되는 db.yml, db_community.yml 목록을 사용하며
Github Actions 스케줄러로 RSS 를 수집하던 중 로그상 수집에 실패하는 사이트 일부를 제거 했습니다.

사용 프로젝트 : [korea-dev-blog-feed-list](https://github.com/korea-dev-blog-feed-list/korea-dev-blog-feed-list)

Github Action 으로 수집된 JSON 데이터를 Github API 를 통해 메신저(디스코드) 봇에서 조회하거나 갱신하는 것을 목적으로 하고 있습니다.