### PR TITLE
삭제된 블로그 제거

### DIFF
--- a/db.yml
+++ b/db.yml
@@ -6006,10 +6006,8 @@
   facebook: https://www.facebook.com/terryum
   github: https://github.com/terryum
   linkedin: https://www.linkedin.com/in/terryum/
-  brunch: https://brunch.co.kr/@terryum
   twitter: https://twitter.com/TerryUm_ML
   youtube: https://www.youtube.com/channel/UCDku86cssbM288VJtl-GQKg
-  home: http://terryum.io/
 - name: 엄태형
   blog: https://brunch.co.kr/@taebari
   rss: https://brunch.co.kr/rss/@@179k

--- a/db_community.yml
+++ b/db_community.yml
@@ -482,7 +482,6 @@
   rss: https://brunch.co.kr/rss/@@c7um
   facebook: https://www.facebook.com/lab4all
   home: https://modulabs.co.kr/
-  tistory: https://www.whydsp.org/
 - name: 모두의연구소 커뮤니티
   facebook: https://www.facebook.com/groups/modulabs/
 - name: 모여서 각자 코딩하는 모임


### PR DESCRIPTION
http://terryum.io/
스팸 사이트가 홈페이지로 등록되어 있음
(whois 조회시 도메인 소유자 국가가 US/NC 입니다)
![awesome-span-1](https://github.com/awesome-devblog/awesome-devblog/assets/140045170/d7c27cdc-c262-4365-a743-1515a174b74e)


https://brunch.co.kr/@terryum
삭제된 브런치스토리 사용자

https://www.whydsp.org/
삭제된 티스토리 블로그

삭제되었다고 판단되는 블로그 목록을 갱신합니다.